### PR TITLE
Add header line support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,19 @@ Command line parameters (./go-wrk -help)
 	
     Usage: go-wrk <options> <url>  
     Options:
-        -H 	 Host Header (Default )
-        -M 	 HTTP method (Default GET)
-        -T 	 Socket/request timeout in ms (Default 1000)
-        -body 	 request body string or @filename (Default )
-        -c 	 Number of goroutines to use (concurrent connections) (Default 10)
-        -d 	 Duration of test in seconds (Default 10)
-        -f 	 Playback file name (Default <empty>)
-        -help 	 Print help (Default false)
-        -no-c 	 Disable Compression - Prevents sending the "Accept-Encoding: gzip" header (Default false)
-        -no-ka 	 Disable KeepAlive - prevents re-use of TCP connections between different HTTP requests (Default false)
-        -redir 	 Allow Redirects (Default false)
-        -v 	 Print version details (Default false)
+        -host    Host Header (Default )
+        -M    HTTP method (Default GET)
+        -T    Socket/request timeout in ms (Default 1000)
+        -H    Header line, joined with semicolon
+        -body    request body string or @filename (Default )
+        -c    Number of goroutines to use (concurrent connections) (Default 10)
+        -d    Duration of test in seconds (Default 10)
+        -f    Playback file name (Default <empty>)
+        -help    Print help (Default false)
+        -no-c    Disable Compression - Prevents sending the "Accept-Encoding: gzip" header (Default false)
+        -no-ka    Disable KeepAlive - prevents re-use of TCP connections between different HTTP requests (Default false)
+        -redir    Allow Redirects (Default false)
+        -v    Print version details (Default false)
 
 Basic Usage
 -----------

--- a/go-wrk.go
+++ b/go-wrk.go
@@ -70,10 +70,12 @@ func main() {
 
 	flag.Parse() // Scan the arguments list
 	header = make(map[string]string)
-	headerPairs := strings.Split(headerStr, ";")
-	for _, hdr := range headerPairs {
-		hp := strings.Split(hdr, ":")
-		header[hp[0]] = hp[1]
+	if headerStr != "" {
+		headerPairs := strings.Split(headerStr, ";")
+		for _, hdr := range headerPairs {
+			hp := strings.Split(hdr, ":")
+			header[hp[0]] = hp[1]
+		}
 	}
 
 	if playbackFile != "<empty>" {


### PR DESCRIPTION
Add header line support in request for setting things like Content-Type, Content-Language, etc. 
Multiple headers are joined with semicolon.

Change the original -H flag to -host, and use the -H as header flag

Update the READEME.md about the changed flag
