### PR TITLE
Add check for StatusCreated in loader

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -152,7 +152,7 @@ func DoRequest(httpClient *http.Client, header map[string]string, method, host, 
 	if err != nil {
 		fmt.Println("An error occured reading body", err)
 	}
-	if resp.StatusCode == http.StatusOK {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		duration = time.Since(start)
 		respSize = len(body) + int(util.EstimateHttpHeadersSize(resp.Header))
 	} else if resp.StatusCode == http.StatusMovedPermanently || resp.StatusCode == http.StatusTemporaryRedirect {


### PR DESCRIPTION
When testing an API that takes POST requests and returns a 201 Created, you don't get any statistics on the result