### PR TITLE
Skip verifying server certificate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
-go-wrk - an HTTP benchmarking tool 
+go-wrk - an HTTP benchmarking tool
 ==================================
 
 go-wrk is a modern HTTP benchmarking tool capable of generating significant load when run on a single multi-core CPU. It builds on go language go routines and scheduler for behind the scenes async IO and concurrency.
 
-It was created mostly to examine go language (http://golang.org) performance and verbosity compared to C (the language wrk was written in. See - <https://github.com/wg/wrk>).  
-It turns out that it is just as good in terms of throughput! And with a lot less code.  
+It was created mostly to examine go language (http://golang.org) performance and verbosity compared to C (the language wrk was written in. See - <https://github.com/wg/wrk>).
+It turns out that it is just as good in terms of throughput! And with a lot less code.
 
 The majority of go-wrk is the product of one afternoon, and its quality is comparable to wrk.
 
 Building
 --------
 
-    go get github.com/tsliwowicz/go-wrk  
+    go get github.com/tsliwowicz/go-wrk
 
-This will download and compile go-wrk. The binary will be placed under your $GOPATH/bin directory  
-   
-Command line parameters (./go-wrk -help)  
-	
-       Usage: go-wrk <options> <url>
-       Options:
-        -H 	 header line, joined with ';' (Default )
-        -M 	 HTTP method (Default GET)
-        -T 	 Socket/request timeout in ms (Default 1000)
-        -body 	 request body string or @filename (Default )
-        -c 	 Number of goroutines to use (concurrent connections) (Default 10)
-        -ca 	 CA file to verify peer against (SSL/TLS) (Default )
-        -cert 	 CA certificate file to verify peer against (SSL/TLS) (Default )
-        -d 	 Duration of test in seconds (Default 10)
-        -f 	 Playback file name (Default <empty>)
-        -help 	 Print help (Default false)
-        -host 	 Host Header (Default )
-        -http 	 Use HTTP/2 (Default true)
-        -key 	 Private key file name (SSL/TLS (Default )
-        -no-c 	 Disable Compression - Prevents sending the "Accept-Encoding: gzip" header (Default false)
-        -no-ka 	 Disable KeepAlive - prevents re-use of TCP connections between different HTTP requests (Default false)
-        -redir 	 Allow Redirects (Default false)
-        -v 	 Print version details (Default false)
+This will download and compile go-wrk. The binary will be placed under your $GOPATH/bin directory
+
+Command line parameters (./go-wrk -help)
+
+    Usage: go-wrk <options> <url>
+    Options:
+      -H   header line, joined with ';' (Default )
+      -M   HTTP method (Default GET)
+      -T   Socket/request timeout in ms (Default 1000)
+      -body    request body string or @filename (Default )
+      -c   Number of goroutines to use (concurrent connections) (Default 10)
+      -ca    CA file to verify peer against (SSL/TLS) (Default )
+      -cert    CA certificate file to verify peer against (SSL/TLS) (Default )
+      -d   Duration of test in seconds (Default 10)
+      -f   Playback file name (Default <empty>)
+      -help    Print help (Default false)
+      -host    Host Header (Default )
+      -http    Use HTTP/2 (Default true)
+      -key   Private key file name (SSL/TLS (Default )
+      -no-c    Disable Compression - Prevents sending the "Accept-Encoding: gzip" header (Default false)
+      -no-ka   Disable KeepAlive - prevents re-use of TCP connections between different HTTP requests (Default false)
+      -no-vr   Skip verifying SSL certificate of the server (Default false)
+      -redir   Allow Redirects (Default false)
+      -v   Print version details (Default false)
 
 Basic Usage
 -----------
@@ -46,15 +47,15 @@ This runs a benchmark for 5 seconds, using 80 go routines (connections)
 
 Output:
 
-    Running 10s test @ http://192.168.1.118:8080/json  
-      80 goroutine(s) running concurrently  
-       142470 requests in 4.949028953s, 19.57MB read  
-         Requests/sec:		28787.47  
-         Transfer/sec:		3.95MB  
-         Avg Req Time:		0.0347ms  
-         Fastest Request:	0.0340ms  
-         Slowest Request:	0.0421ms  
-         Number of Errors:	0  
+    Running 10s test @ http://192.168.1.118:8080/json
+      80 goroutine(s) running concurrently
+       142470 requests in 4.949028953s, 19.57MB read
+         Requests/sec:		28787.47
+         Transfer/sec:		3.95MB
+         Avg Req Time:		0.0347ms
+         Fastest Request:	0.0340ms
+         Slowest Request:	0.0421ms
+         Number of Errors:	0
 
 
 Benchmarking Tips
@@ -68,6 +69,6 @@ Benchmarking Tips
 Acknowledgements
 ----------------
 
-  golang is awesome. I did not need anything but this to create go-wrk.  
-  I fully credit the wrk project (https://github.com/wg/wrk) for the inspiration and even parts of this text.  
+  golang is awesome. I did not need anything but this to create go-wrk.
+  I fully credit the wrk project (https://github.com/wg/wrk) for the inspiration and even parts of this text.
   I also used similar command line arguments format and output format.

--- a/go-wrk.go
+++ b/go-wrk.go
@@ -31,6 +31,7 @@ var timeoutms int
 var allowRedirectsFlag bool = false
 var disableCompression bool
 var disableKeepAlive bool
+var skipVerify bool
 var playbackFile string
 var reqBody string
 var clientCert string
@@ -44,6 +45,7 @@ func init() {
 	flag.BoolVar(&helpFlag, "help", false, "Print help")
 	flag.BoolVar(&disableCompression, "no-c", false, "Disable Compression - Prevents sending the \"Accept-Encoding: gzip\" header")
 	flag.BoolVar(&disableKeepAlive, "no-ka", false, "Disable KeepAlive - prevents re-use of TCP connections between different HTTP requests")
+	flag.BoolVar(&skipVerify, "no-vr", false, "Skip verifying SSL certificate of the server")
 	flag.IntVar(&goroutines, "c", 10, "Number of goroutines to use (concurrent connections)")
 	flag.IntVar(&duration, "d", 10, "Duration of test in seconds")
 	flag.IntVar(&timeoutms, "T", 1000, "Socket/request timeout in ms")
@@ -124,7 +126,7 @@ func main() {
 	}
 
 	loadGen := loader.NewLoadCfg(duration, goroutines, testUrl, reqBody, method, host, header, statsAggregator, timeoutms,
-		allowRedirectsFlag, disableCompression, disableKeepAlive, clientCert, clientKey, caCert, http2)
+		allowRedirectsFlag, disableCompression, disableKeepAlive, skipVerify, clientCert, clientKey, caCert, http2)
 
 	for i := 0; i < goroutines; i++ {
 		go loadGen.RunSingleLoadSession()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tsliwowicz/go-wrk
+
+go 1.14
+
+require golang.org/x/net v0.0.0-20200319234117-63522dbf7eec

--- a/loader/client.go
+++ b/loader/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tsliwowicz/go-wrk/util"
 )
 
-func client(disableCompression bool, disableKeepAlive bool, timeoutms int, allowRedirects bool, clientCert, clientKey, caCert string, usehttp2 bool) (*http.Client, error) {
+func client(disableCompression, disableKeepAlive, skipVerify bool, timeoutms int, allowRedirects bool, clientCert, clientKey, caCert string, usehttp2 bool) (*http.Client, error) {
 
 	client := &http.Client{}
 	//overriding the default parameters
@@ -21,6 +21,7 @@ func client(disableCompression bool, disableKeepAlive bool, timeoutms int, allow
 		DisableCompression:    disableCompression,
 		DisableKeepAlives:     disableKeepAlive,
 		ResponseHeaderTimeout: time.Millisecond * time.Duration(timeoutms),
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: skipVerify},
 	}
 
 	if !allowRedirects {
@@ -56,8 +57,9 @@ func client(disableCompression bool, disableKeepAlive bool, timeoutms int, allow
 	clientCertPool.AppendCertsFromPEM(clientCACert)
 
 	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      clientCertPool,
+		Certificates:       []tls.Certificate{cert},
+		RootCAs:            clientCertPool,
+		InsecureSkipVerify: skipVerify,
 	}
 
 	tlsConfig.BuildNameToCertificate()

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -32,6 +32,7 @@ type LoadCfg struct {
 	allowRedirects     bool
 	disableCompression bool
 	disableKeepAlive   bool
+	skipVerify	 	   bool
 	interrupted        int32
 	clientCert         string
 	clientKey          string
@@ -61,12 +62,13 @@ func NewLoadCfg(duration int, //seconds
 	allowRedirects bool,
 	disableCompression bool,
 	disableKeepAlive bool,
+	skipVerify bool,
 	clientCert string,
 	clientKey string,
 	caCert string,
 	http2 bool) (rt *LoadCfg) {
 	rt = &LoadCfg{duration, goroutines, testUrl, reqBody, method, host, header, statsAggregator, timeoutms,
-		allowRedirects, disableCompression, disableKeepAlive, 0, clientCert, clientKey, caCert, http2}
+		allowRedirects, disableCompression, disableKeepAlive, skipVerify, 0, clientCert, clientKey, caCert, http2}
 	return
 }
 
@@ -171,7 +173,8 @@ func (cfg *LoadCfg) RunSingleLoadSession() {
 	stats := &RequesterStats{MinRequestTime: time.Minute}
 	start := time.Now()
 
-	httpClient, err := client(cfg.disableCompression, cfg.disableKeepAlive, cfg.timeoutms, cfg.allowRedirects, cfg.clientCert, cfg.clientKey, cfg.caCert, cfg.http2)
+	httpClient, err := client(cfg.disableCompression, cfg.disableKeepAlive, cfg.skipVerify, 
+		cfg.timeoutms, cfg.allowRedirects, cfg.clientCert, cfg.clientKey, cfg.caCert, cfg.http2)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
For testing locally it's convenient to disable SSL certificates validation. To avoid errors:

> An error occured doing request Post "https://127.0.0.3/f": x509: cannot validate certificate for 127.0.0.3 because it doesn't contain any IP SANs

so I added an option -no-vr to disable sertificate validation. By default it's enabled