### PR TITLE
ability to pass mulitple -H options for headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 go-wrk - an HTTP benchmarking tool
 ==================================
 
-go-wrk is a modern HTTP benchmarking tool capable of generating significant load when run on a single multi-core CPU. It builds on go language go routines and scheduler for behind the scenes async IO and concurrency.
-
-It was created mostly to examine go language (http://golang.org) performance and verbosity compared to C (the language wrk was written in. See - <https://github.com/wg/wrk>).
-It turns out that it is just as good in terms of throughput! And with a lot less code.
-
-The majority of go-wrk is the product of one afternoon, and its quality is comparable to wrk.
+This is a fork of the wonderful https://github.com/tsliwowicz/go-wrk I did not create the code, only added a single new feature (better header parsing) https://github.com/tsliwowicz/go-wrk/pull/19 Use at your own risk.
 
 Building
 --------
 
-    go get github.com/tsliwowicz/go-wrk
+    go get github.com/elodani/go-wrk
 
 This will download and compile go-wrk. The binary will be placed under your $GOPATH/bin directory
 
@@ -68,6 +63,4 @@ Benchmarking Tips
 Acknowledgements
 ----------------
 
-  golang is awesome. I did not need anything but this to create go-wrk.
-  I fully credit the wrk project (https://github.com/wg/wrk) for the inspiration and even parts of this text.
-  I also used similar command line arguments format and output format.
+  All credits due to https://github.com/tsliwowicz

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-go-wrk - an HTTP benchmarking tool 
+go-wrk - an HTTP benchmarking tool
 ==================================
 
 go-wrk is a modern HTTP benchmarking tool capable of generating significant load when run on a single multi-core CPU. It builds on go language go routines and scheduler for behind the scenes async IO and concurrency.
 
-It was created mostly to examine go language (http://golang.org) performance and verbosity compared to C (the language wrk was written in. See - <https://github.com/wg/wrk>).  
-It turns out that it is just as good in terms of throughput! And with a lot less code.  
+It was created mostly to examine go language (http://golang.org) performance and verbosity compared to C (the language wrk was written in. See - <https://github.com/wg/wrk>).
+It turns out that it is just as good in terms of throughput! And with a lot less code.
 
 The majority of go-wrk is the product of one afternoon, and its quality is comparable to wrk.
 
 Building
 --------
 
-    go get github.com/tsliwowicz/go-wrk  
+    go get github.com/tsliwowicz/go-wrk
 
-This will download and compile go-wrk. The binary will be placed under your $GOPATH/bin directory  
-   
-Command line parameters (./go-wrk -help)  
-	
+This will download and compile go-wrk. The binary will be placed under your $GOPATH/bin directory
+
+Command line parameters (./go-wrk -help)
+
        Usage: go-wrk <options> <url>
        Options:
-        -H 	 header line, joined with ';' (Default )
+        -H 	 Request header (Default )
         -M 	 HTTP method (Default GET)
         -T 	 Socket/request timeout in ms (Default 1000)
         -body 	 request body string or @filename (Default )
@@ -46,15 +46,15 @@ This runs a benchmark for 5 seconds, using 80 go routines (connections)
 
 Output:
 
-    Running 10s test @ http://192.168.1.118:8080/json  
-      80 goroutine(s) running concurrently  
-       142470 requests in 4.949028953s, 19.57MB read  
-         Requests/sec:		28787.47  
-         Transfer/sec:		3.95MB  
-         Avg Req Time:		0.0347ms  
-         Fastest Request:	0.0340ms  
-         Slowest Request:	0.0421ms  
-         Number of Errors:	0  
+    Running 10s test @ http://192.168.1.118:8080/json
+      80 goroutine(s) running concurrently
+       142470 requests in 4.949028953s, 19.57MB read
+         Requests/sec:		28787.47
+         Transfer/sec:		3.95MB
+         Avg Req Time:		0.0347ms
+         Fastest Request:	0.0340ms
+         Slowest Request:	0.0421ms
+         Number of Errors:	0
 
 
 Benchmarking Tips
@@ -68,6 +68,6 @@ Benchmarking Tips
 Acknowledgements
 ----------------
 
-  golang is awesome. I did not need anything but this to create go-wrk.  
-  I fully credit the wrk project (https://github.com/wg/wrk) for the inspiration and even parts of this text.  
+  golang is awesome. I did not need anything but this to create go-wrk.
+  I fully credit the wrk project (https://github.com/wg/wrk) for the inspiration and even parts of this text.
   I also used similar command line arguments format and output format.

--- a/go-wrk.go
+++ b/go-wrk.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tsliwowicz/go-wrk/loader"
-	"github.com/tsliwowicz/go-wrk/util"
+	"./loader"
+	"./util"
 )
 
-const APP_VERSION = "0.1"
+const APP_VERSION = "0.2"
 
 //default that can be overridden from the command line
 var versionFlag bool = false
@@ -24,7 +24,7 @@ var goroutines int = 2
 var testUrl string
 var method string = "GET"
 var host string
-var headerStr string
+var headerFlags util.HeaderList
 var header map[string]string
 var statsAggregator chan *loader.RequesterStats
 var timeoutms int
@@ -49,7 +49,7 @@ func init() {
 	flag.IntVar(&timeoutms, "T", 1000, "Socket/request timeout in ms")
 	flag.StringVar(&method, "M", "GET", "HTTP method")
 	flag.StringVar(&host, "host", "", "Host Header")
-	flag.StringVar(&headerStr, "H", "", "header line, joined with ';'")
+	flag.Var(&headerFlags, "H", "Header to add to each request (you can define multiple -H flags)")
 	flag.StringVar(&playbackFile, "f", "<empty>", "Playback file name")
 	flag.StringVar(&reqBody, "body", "", "request body string or @filename")
 	flag.StringVar(&clientCert, "cert", "", "CA certificate file to verify peer against (SSL/TLS)")
@@ -78,13 +78,12 @@ func main() {
 
 	flag.Parse() // Scan the arguments list
 	header = make(map[string]string)
-	if headerStr != "" {
-		headerPairs := strings.Split(headerStr, ";")
-		for _, hdr := range headerPairs {
+	if headerFlags != nil {
+		for _, hdr := range headerFlags {
 			hp := strings.SplitN(hdr, ":", 2)
 			header[hp[0]] = hp[1]
 		}
-	}
+    }
 
 	if playbackFile != "<empty>" {
 		file, err := os.Open(playbackFile) // For read access.

--- a/util/util.go
+++ b/util/util.go
@@ -3,8 +3,25 @@ package util
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
+
+type HeaderList []string
+
+func (i *HeaderList) String() string {
+	out := []string{}
+    for _, s := range *i {
+        out = append(out, s)
+    }
+    return strings.Join(out, ", ")
+}
+
+func (i *HeaderList) Set(value string) error {
+    *i = append(*i, value)
+    return nil
+}
+
 
 // RedirectError specific error type that happens on redirection
 type RedirectError struct {


### PR DESCRIPTION
This way we can pass cookie headers where ; is contained in header value, as we are no longer splitting on any special character.

fixes issue https://github.com/tsliwowicz/go-wrk/issues/14