### PR TITLE
Add Docker support and update README with usage instructions

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,40 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/go-wrk
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release metadata
+        id: meta
+        run: |
+          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21 AS builder
+WORKDIR /src
+
+# Pre-download dependencies for layer caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/go-wrk .
+
+FROM alpine:3.20
+RUN apk --no-cache add ca-certificates
+COPY --from=builder /out/go-wrk /usr/local/bin/go-wrk
+
+ENTRYPOINT ["/usr/local/bin/go-wrk"]
+CMD ["-help"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,29 @@ Building
 
 This will download and compile go-wrk. 
    
-Command line parameters (./go-wrk -help)  
+Docker
+------
+
+An official container image is published as `ghcr.io/tsliwowicz/go-wrk`. Run it with the same flags you would pass to the binary:
+
+```
+docker run --rm ghcr.io/tsliwowicz/go-wrk -c 256 -d 30 http://host.docker.internal:8080/plaintext
+```
+
+Use `host.docker.internal` (Mac/Windows) or your host IP (Linux) when benchmarking services on the same machine, and mount local files if you need to reference request bodies or playback files:
+
+```
+docker run --rm -v "$PWD/scripts:/scripts" ghcr.io/tsliwowicz/go-wrk -f /scripts/playback.json https://example.com
+```
+
+For an interactive shell inside the image, override the entrypoint:
+
+```
+docker run -it --rm --entrypoint /bin/sh ghcr.io/tsliwowicz/go-wrk
+```
+
+Command line parameters (./go-wrk -help)
+---  
 	
        Usage: go-wrk <options> <url>
        Options:


### PR DESCRIPTION
This pull request introduces official Docker support for the project, making it easier to build, publish, and use `go-wrk` as a container image. The main changes include adding a Dockerfile, setting up a GitHub Actions workflow to automatically build and publish the image on release, and updating documentation to describe how to use the new container image.

**Docker support and automation:**

* Added a `Dockerfile` to build a minimal container image for `go-wrk`, using a multi-stage build for efficiency and security.
* Introduced a GitHub Actions workflow (`.github/workflows/release-image.yml`) to automatically build and publish the Docker image to GitHub Container Registry on every release.

**Documentation updates:**

* Updated the `README.md` to document the official container image, including usage instructions and examples for running `go-wrk` in Docker.